### PR TITLE
Added designguide fonts

### DIFF
--- a/latex_template.tex
+++ b/latex_template.tex
@@ -11,21 +11,33 @@
 \usepackage{tikz}
 \usetikzlibrary{positioning,arrows}
 \usepackage{listings}
-
+\usepackage{titlesec}
 \renewcommand{\headrulewidth}{0pt}
-
-
+\usepackage{fontspec}
+\setmainfont{Georgia}
+\setsansfont{Gill Sans}
 
 \title{Dokumentets titel}
-\author{Coding Pirates (afdeling)} 
-\date{Indsæt dato her}
+\author{\sffamily Coding Pirates (afdeling)}
+\date{\sffamily Indsæt dato her}
 
-\setkomafont{title}{\normalfont\bfseries}
+\setkomafont{title}{\sffamily\bfseries}
 \makeatletter
 \let\doctitle\@title
-\patchcmd{\@maketitle}{\titlefont\huge}{\titlefont\HUGE}{}{}
+\patchcmd{\@maketitle}{\sffamily\huge}{\sffamily\HUGE}{}{}
 \makeatother
 
+\titleformat{\section}
+  {\Large\sffamily\bfseries}
+  {\thesection}
+  {1em}
+  {}
+
+\titleformat{\title}
+{\Large\sffamily\bfseries}
+{\thetitle}
+{1em}
+{}
 
 
 


### PR DESCRIPTION
Jeg bruger den har skabelon til HB's referater. 

Jeg har opdateret sådan at den bruger de skrifttyper redaktionen har skrevet i design guidelines. 
Desværre er det sådan nogle _moderne_ skrifttyper så `pdflatex` er ikke nok og man skal istedet bygge pdf'en med `xelatex`. 

Synes du vi skal merge ændringerne ind når de kræver det @ragnarreynisson? 

Jeg er for det, da du ihvertfald får `xelatex` med når du installere MacTex, gætter på det også er tilfældet ved Linux & Windows. 
